### PR TITLE
Add domain model & mocks

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,0 +1,42 @@
+package mock
+
+import (
+	"github.com/benbjohnson/wtf"
+)
+
+type DialService struct {
+	DialFn      func(id wtf.DialID) (*wtf.Dial, error)
+	DialInvoked bool
+
+	CreateDialFn      func(dial *wtf.Dial) error
+	CreateDialInvoked bool
+
+	SetLevelFn      func(id wtf.DialID, level float64) error
+	SetLevelInvoked bool
+}
+
+func (s *DialService) Dial(id wtf.DialID) (*wtf.Dial, error) {
+	s.DialInvoked = true
+	return s.DialFn(id)
+}
+
+func (s *DialService) CreateDial(dial *wtf.Dial) error {
+	s.CreateDialInvoked = true
+	return s.CreateDialFn(dial)
+}
+
+func (s *DialService) SetLevel(id wtf.DialID, level float64) error {
+	s.SetLevelInvoked = true
+	return s.SetLevelFn(id, level)
+}
+
+// UserService represents a service for managing user authentication.
+type UserService struct {
+	AuthenticateFn      func(token string) (*wtf.User, error)
+	AuthenticateInvoked bool
+}
+
+func (s *UserService) Authenticate(token string) (*wtf.User, error) {
+	s.AuthenticateInvoked = true
+	return s.AuthenticateFn(token)
+}

--- a/wtf.go
+++ b/wtf.go
@@ -1,0 +1,38 @@
+package wtf
+
+import (
+	"time"
+)
+
+// UserID represents a user identifier.
+type UserID int
+
+// User represents an authenticated user of the system.
+type User struct {
+	ID       UserID `json:"id"`
+	Username string `json:"username"`
+}
+
+// DialID represents a dial identifier.
+type DialID int
+
+// Dial represents an adjustable WTF level associated with a user.
+type Dial struct {
+	ID      DialID    `json:"dialID"`
+	UserID  UserID    `json:"userID"`
+	Name    string    `json:"name,omitempty"`
+	Level   float64   `json:"level"`
+	ModTime time.Time `json:"modTime"`
+}
+
+// UserService represents a service for managing users.
+type UserService interface {
+	Authenticate(token string) (*User, error)
+}
+
+// DialService represents a service for managing dials.
+type DialService interface {
+	Dial(id DialID) (*Dial, error)
+	CreateDial(dial *Dial) error
+	SetLevel(id DialID, level float64) error
+}


### PR DESCRIPTION
## Overview

This pull request adds a simple domain model of `Gauge`, `User`, and `UserInput` to the root package. Two services are also provided, `GaugeService` and `UserService`, along with mock implementations.

Related blog post: [Building WTF Dial: Domain Model & Mocks](https://medium.com/@benbjohnson/wtf-dial-domain-model-9655cd523182)


## Package organization

This project is using the package model that I detailed in [Standard Package Layout](https://medium.com/@benbjohnson/standard-package-layout-7cdbc8391fc1). The domain of the WTF Dial consists of a _Gauge_ which is an aggregate of all the WTF _Input Values_ specified by the _Users_ of the system.

A service interface is provided for the gauges so that they can be created, deleted, and retrieved. We may want to update their names later but that's not a big concern right now. The gauge itself gets mutated by inputs by the user.

Another service interface is provided for authenticating users. Initially I want to keep this project simple and avoid the headache of user registration, login, password resets, etc and simply use GitHub personal access token authentication.


## Mocks

Once we begin building implementations of our services and different access methods (e.g. HTTP) then we'll want to test those in isolation. Mocks are provided as a simple way to do this. They are structs that implement the services but provide fields to set the implementation that we want.

You can also use other tools for generating more complex mocks but I just like to handwrite mine and keep them simple.