### PR TITLE
Add GitHub Authenticator

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"net/http"
+
+	"github.com/benbjohnson/wtf"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// Ensure *Authenticator implements wtf.Authenticator.
+var _ wtf.Authenticator = &Authenticator{}
+
+// Authenticator represents a authenticator using GitHub tokens.
+type Authenticator struct{}
+
+// Authenticate retrieves the authenticated user using token.
+func (a *Authenticator) Authenticate(token string) (*wtf.User, error) {
+	// Create a new OAuth2 authenticated GitHub client.
+	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	client := github.NewClient(oauth2.NewClient(oauth2.NoContext, source))
+
+	// Fetch the current user.
+	u, resp, err := client.Users.Get("")
+	if err != nil {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return nil, wtf.ErrUnauthorized
+		default:
+			return nil, err
+		}
+	}
+
+	// Return the user as a WTF user.
+	return &wtf.User{
+		ID:       wtf.UserID(*u.ID),
+		Username: *u.Login,
+	}, nil
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,54 @@
+package github_test
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+
+	"github.com/benbjohnson/wtf"
+	"github.com/benbjohnson/wtf/github"
+)
+
+// Integration testing flags.
+var (
+	intg     = flag.Bool("intg", false, "enable integration testing")
+	token    = flag.String("token", "", "auth token")
+	userID   = flag.Int("user-id", 0, "auth user id")
+	username = flag.String("username", "", "auth username")
+)
+
+// Ensure authenticator can successfully authenticate a user.
+func TestAuthenticator_Authenticate(t *testing.T) {
+	if !*intg {
+		t.Skip("integration testing not enabled")
+	}
+
+	// Ignore test if token or username is not passed in.
+	if *token == "" || *userID == 0 || *username == "" {
+		t.Skip("all flags not set: -token, -user-id, -username")
+	}
+
+	// Create an expected user object.
+	exp := &wtf.User{ID: wtf.UserID(*userID), Username: *username}
+
+	// Authenticate using token, verify it matches username.
+	var a github.Authenticator
+	if u, err := a.Authenticate(*token); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(exp, u) {
+		t.Fatalf("Authenticate() = %#v; want %#v", u, exp)
+	}
+}
+
+// Ensure authenticator returns an error if user is not authorized.
+func TestAuthenticator_Authenticate_ErrUnauthorized(t *testing.T) {
+	if !*intg {
+		t.Skip("integration testing not enabled")
+	}
+
+	// Authenticate using invalid token.
+	var a github.Authenticator
+	if _, err := a.Authenticate("INVALID_TOKEN"); err != wtf.ErrUnauthorized {
+		t.Fatalf("unexpected error: %s")
+	}
+}


### PR DESCRIPTION
## Overview

Implements `wtf.Authenticator` using GitHub. Integration tests can be run by specifying the `-intg` flag and other associated flags:

	-token TOKEN
		Specifies the GitHub personal access token.
	-user-id ID
		GitHub user ID associated with the token.
	-username USERNAME
		GitHub username assocaited with the token.

## Usage

```sh
$ cd $GOPATH/src/github.com/benbjohnson/wtf
$ go test ./github/ -intg -token=XYZ -user-id=123 -username=MYUSER
```