### PR TITLE
Add HTTP API.

### DIFF
--- a/bolt/dial_service.go
+++ b/bolt/dial_service.go
@@ -34,8 +34,10 @@ func (s *DialService) Dial(id wtf.DialID) (*wtf.Dial, error) {
 
 // CreateDial creates a new dial.
 func (s *DialService) CreateDial(d *wtf.Dial) error {
-	// Require id.
-	if d.ID == "" {
+	// Require object and id.
+	if d == nil {
+		return wtf.ErrDialRequired
+	} else if d.ID == "" {
 		return wtf.ErrDialIDRequired
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -3,10 +3,12 @@ package wtf
 // General errors.
 const (
 	ErrUnauthorized = Error("unauthorized")
+	ErrInternal     = Error("internal error")
 )
 
 // Dial errors.
 const (
+	ErrDialRequired   = Error("dial required")
 	ErrDialNotFound   = Error("dial not found")
 	ErrDialExists     = Error("dial already exists")
 	ErrDialIDRequired = Error("dial id required")

--- a/http/dial_service.go
+++ b/http/dial_service.go
@@ -1,0 +1,228 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/benbjohnson/wtf"
+	"github.com/julienschmidt/httprouter"
+)
+
+// DialHandler represents an HTTP API handler for dials.
+type DialHandler struct {
+	*httprouter.Router
+
+	DialService wtf.DialService
+
+	Logger *log.Logger
+}
+
+// NewDialHandler returns a new instance of DialHandler.
+func NewDialHandler() *DialHandler {
+	h := &DialHandler{
+		Router: httprouter.New(),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
+	}
+	h.POST("/api/dials", h.handlePostDial)
+	h.GET("/api/dials/:id", h.handleGetDial)
+	h.PATCH("/api/dials/:id", h.handlePatchDial)
+	return h
+}
+
+// handleGetDial handles requests to fetch a single dial.
+func (h *DialHandler) handleGetDial(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	id := ps.ByName("id")
+
+	// Find dial by ID.
+	d, err := h.DialService.Dial(wtf.DialID(id))
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, h.Logger)
+	} else if d == nil {
+		NotFound(w)
+	} else {
+		encodeJSON(w, &getDialResponse{Dial: d}, h.Logger)
+	}
+}
+
+type getDialResponse struct {
+	Dial *wtf.Dial `json:"dial,omitempty"`
+	Err  string    `json:"err,omitempty"`
+}
+
+// handleGetDial handles requests to create a new dial.
+func (h *DialHandler) handlePostDial(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Decode request.
+	var req postDialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, ErrInvalidJSON, http.StatusBadRequest, h.Logger)
+		return
+	}
+	d := req.Dial
+	d.Token = req.Token
+	d.ModTime = time.Time{}
+
+	// Create dial.
+	switch err := h.DialService.CreateDial(d); err {
+	case nil:
+		encodeJSON(w, &postDialResponse{Dial: d}, h.Logger)
+	case wtf.ErrDialRequired, wtf.ErrDialIDRequired:
+		Error(w, err, http.StatusBadRequest, h.Logger)
+	case wtf.ErrDialExists:
+		Error(w, err, http.StatusConflict, h.Logger)
+	default:
+		Error(w, err, http.StatusInternalServerError, h.Logger)
+	}
+}
+
+type postDialRequest struct {
+	Dial  *wtf.Dial `json:"dial,omitempty"`
+	Token string    `json:"token,omitempty"`
+}
+
+type postDialResponse struct {
+	Dial *wtf.Dial `json:"dial,omitempty"`
+	Err  string    `json:"err,omitempty"`
+}
+
+// handlePatchDial handles requests to update a dial level.
+func (h *DialHandler) handlePatchDial(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Decode request.
+	var req patchDialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, ErrInvalidJSON, http.StatusBadRequest, h.Logger)
+		return
+	}
+
+	// Create dial.
+	switch err := h.DialService.SetLevel(req.ID, req.Token, req.Level); err {
+	case nil:
+		encodeJSON(w, &patchDialResponse{}, h.Logger)
+	case wtf.ErrDialNotFound:
+		Error(w, err, http.StatusNotFound, h.Logger)
+	case wtf.ErrUnauthorized:
+		Error(w, err, http.StatusUnauthorized, h.Logger)
+	default:
+		Error(w, err, http.StatusInternalServerError, h.Logger)
+	}
+}
+
+type patchDialRequest struct {
+	ID    wtf.DialID `json:"id"`
+	Token string     `json:"token"`
+	Level float64    `json:"level"`
+}
+
+type patchDialResponse struct {
+	Err string `json:"err,omitempty"`
+}
+
+// Ensure service implements interface.
+var _ wtf.DialService = &DialService{}
+
+// DialService represents an HTTP implementation of wtf.DialService.
+type DialService struct {
+	URL *url.URL
+}
+
+// Dial returns a dial by id.
+func (s *DialService) Dial(id wtf.DialID) (*wtf.Dial, error) {
+	u := *s.URL
+	u.Path = "/api/dials/" + url.QueryEscape(string(id))
+
+	// Execute request.
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into JSON.
+	var respBody getDialResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return nil, err
+	} else if respBody.Err != "" {
+		return nil, wtf.Error(respBody.Err)
+	}
+	return respBody.Dial, nil
+}
+
+// CreateDial creates a new dial.
+func (s *DialService) CreateDial(d *wtf.Dial) error {
+	// Validate arguments.
+	if d == nil {
+		return wtf.ErrDialRequired
+	}
+
+	u := *s.URL
+	u.Path = "/api/dials"
+
+	// Save token.
+	token := d.Token
+
+	// Encode request body.
+	reqBody, err := json.Marshal(postDialRequest{Dial: d, Token: token})
+	if err != nil {
+		return err
+	}
+
+	// Execute request.
+	resp, err := http.Post(u.String(), "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into JSON.
+	var respBody postDialResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return err
+	} else if respBody.Err != "" {
+		return wtf.Error(respBody.Err)
+	}
+
+	// Copy returned dial.
+	*d = *respBody.Dial
+	d.Token = token
+
+	return nil
+}
+
+// SetLevel sets the level of an existing dial.
+func (s *DialService) SetLevel(id wtf.DialID, token string, level float64) error {
+	u := *s.URL
+	u.Path = "/api/dials/" + url.QueryEscape(string(id))
+
+	// Encode request body.
+	reqBody, err := json.Marshal(patchDialRequest{ID: id, Token: token, Level: level})
+	if err != nil {
+		return err
+	}
+
+	// Create request.
+	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+
+	// Execute request.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into JSON.
+	var respBody postDialResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return err
+	} else if respBody.Err != "" {
+		return wtf.Error(respBody.Err)
+	}
+
+	return nil
+}

--- a/http/dial_service_test.go
+++ b/http/dial_service_test.go
@@ -1,0 +1,248 @@
+package http_test
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/benbjohnson/wtf"
+	"github.com/benbjohnson/wtf/http"
+	"github.com/benbjohnson/wtf/mock"
+)
+
+func TestDialService_Dial(t *testing.T) {
+	t.Run("OK", testDialService_Dial)
+	t.Run("NotFound", testDialService_Dial_NotFound)
+	t.Run("ErrInternal", testDialService_Dial_ErrInternal)
+}
+
+// Ensure service can return a single dial.
+func testDialService_Dial(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+
+	// Mock service.
+	s.Handler.DialHandler.DialService.DialFn = func(id wtf.DialID) (*wtf.Dial, error) {
+		if id != "XXX" {
+			t.Fatalf("unexpected id: %s", id)
+		}
+		return &wtf.Dial{ID: id, Name: "NAME", Level: 100, Token: "TOKEN", ModTime: Now}, nil
+	}
+
+	// Retrieve dial.
+	d, err := c.DialService().Dial("XXX")
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(d, &wtf.Dial{ID: "XXX", Name: "NAME", Level: 100, ModTime: Now}) {
+		t.Fatalf("unexpected dial: %#v", d)
+	}
+}
+
+// Ensure service handles fetching a non-existent dial.
+func testDialService_Dial_NotFound(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+
+	// Mock service.
+	s.Handler.DialHandler.DialService.DialFn = func(id wtf.DialID) (*wtf.Dial, error) {
+		return nil, nil
+	}
+
+	// Retrieve dial.
+	if d, err := c.DialService().Dial("NO_SUCH_DIAL"); err != nil {
+		t.Fatal(err)
+	} else if d != nil {
+		t.Fatal("expected nil dial")
+	}
+}
+
+// Ensure service returns an internal error if an error occurs.
+func testDialService_Dial_ErrInternal(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+
+	// Mock service.
+	s.Handler.DialHandler.DialService.DialFn = func(id wtf.DialID) (*wtf.Dial, error) {
+		return nil, errors.New("marker")
+	}
+
+	// Retrieve dial.
+	if _, err := c.DialService().Dial("XXX"); err != wtf.ErrInternal {
+		t.Fatal(err)
+	} else if !strings.Contains(s.Handler.DialHandler.LogOutput.String(), "marker") {
+		t.Fatalf("expected log output")
+	}
+}
+
+func TestDialService_CreateDial(t *testing.T) {
+	t.Run("OK", testDialService_CreateDial)
+	t.Run("ErrDialRequired", testDialService_CreateDial_ErrDialRequired)
+	t.Run("ErrDialIDRequired", testDialService_CreateDial_ErrDialIDRequired)
+	t.Run("ErrDialExists", testDialService_CreateDial_ErrDialExists)
+	t.Run("ErrInternal", testDialService_CreateDial_ErrInternal)
+}
+
+// Ensure service can create a new dial.
+func testDialService_CreateDial(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+
+	// Mock service.
+	s.Handler.DialHandler.DialService.CreateDialFn = func(d *wtf.Dial) error {
+		if !reflect.DeepEqual(d, &wtf.Dial{ID: "XXX", Token: "TOKEN", Name: "NAME", Level: 100}) {
+			t.Fatalf("unexpected dial: %#v", d)
+		}
+
+		// Update mod time.
+		d.ModTime = Now
+
+		return nil
+	}
+
+	d := &wtf.Dial{ID: "XXX", Token: "TOKEN", Name: "NAME", Level: 100}
+
+	// Create dial.
+	err := c.DialService().CreateDial(d)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(d, &wtf.Dial{ID: "XXX", Token: "TOKEN", Name: "NAME", Level: 100, ModTime: Now}) {
+		t.Fatalf("unexpected dial: %#v", d)
+	}
+}
+
+// Ensure service returns an error if no dial is passed in.
+func testDialService_CreateDial_ErrDialRequired(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	if err := c.DialService().CreateDial(nil); err != wtf.ErrDialRequired {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if dial id is passed blank.
+func testDialService_CreateDial_ErrDialIDRequired(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.CreateDialFn = func(d *wtf.Dial) error {
+		return wtf.ErrDialIDRequired
+	}
+	if err := c.DialService().CreateDial(&wtf.Dial{}); err != wtf.ErrDialIDRequired {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if dial already exists.
+func testDialService_CreateDial_ErrDialExists(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.CreateDialFn = func(d *wtf.Dial) error {
+		return wtf.ErrDialExists
+	}
+	if err := c.DialService().CreateDial(&wtf.Dial{ID: "XXX"}); err != wtf.ErrDialExists {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if an internal error occurs.
+func testDialService_CreateDial_ErrInternal(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.CreateDialFn = func(d *wtf.Dial) error {
+		return errors.New("marker")
+	}
+
+	if err := c.DialService().CreateDial(&wtf.Dial{ID: "XXX"}); err != wtf.ErrInternal {
+		t.Fatal(err)
+	} else if !strings.Contains(s.Handler.DialHandler.LogOutput.String(), "marker") {
+		t.Fatalf("expected log output")
+	}
+}
+
+func TestDialService_SetLevel(t *testing.T) {
+	t.Run("OK", testDialService_SetLevel)
+	t.Run("ErrDialNotFound", testDialService_SetLevel_ErrDialNotFound)
+	t.Run("ErrUnauthorized", testDialService_SetLevel_ErrUnauthorized)
+	t.Run("ErrInternal", testDialService_SetLevel_ErrInternal)
+}
+
+// Ensure service can set the level of an existing dial.
+func testDialService_SetLevel(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+
+	// Mock service.
+	s.Handler.DialHandler.DialService.SetLevelFn = func(id wtf.DialID, token string, level float64) error {
+		if id != "XXX" {
+			t.Fatalf("unexpected dial id: %s", id)
+		} else if token != "TOKEN" {
+			t.Fatalf("unexpected token: %s", token)
+		} else if level != 100 {
+			t.Fatalf("unexpected level: %v", level)
+		}
+		return nil
+	}
+
+	// Set dial level.
+	err := c.DialService().SetLevel("XXX", "TOKEN", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if the dial doesn't exist.
+func testDialService_SetLevel_ErrDialNotFound(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.SetLevelFn = func(id wtf.DialID, token string, level float64) error {
+		return wtf.ErrDialNotFound
+	}
+	if err := c.DialService().SetLevel("XXX", "", 100); err != wtf.ErrDialNotFound {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if the user is not authorized.
+func testDialService_SetLevel_ErrUnauthorized(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.SetLevelFn = func(id wtf.DialID, token string, level float64) error {
+		return wtf.ErrUnauthorized
+	}
+	if err := c.DialService().SetLevel("XXX", "", 100); err != wtf.ErrUnauthorized {
+		t.Fatal(err)
+	}
+}
+
+// Ensure service returns an error if an internal error occurs.
+func testDialService_SetLevel_ErrInternal(t *testing.T) {
+	s, c := MustOpenServerClient()
+	defer s.Close()
+	s.Handler.DialHandler.DialService.SetLevelFn = func(id wtf.DialID, token string, level float64) error {
+		return errors.New("marker")
+	}
+
+	if err := c.DialService().SetLevel("XXX", "", 100); err != wtf.ErrInternal {
+		t.Fatal(err)
+	} else if !strings.Contains(s.Handler.DialHandler.LogOutput.String(), "marker") {
+		t.Fatalf("expected log output")
+	}
+}
+
+// DialHandler represents a test wrapper for http.DialHandler.
+type DialHandler struct {
+	*http.DialHandler
+
+	DialService mock.DialService
+	LogOutput   bytes.Buffer
+}
+
+// NewDialHandler returns a new instance of DialHandler.
+func NewDialHandler() *DialHandler {
+	h := &DialHandler{DialHandler: http.NewDialHandler()}
+	h.DialHandler.DialService = &h.DialService
+	h.Logger = log.New(VerboseWriter(&h.LogOutput), "", log.LstdFlags)
+	return h
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -1,0 +1,59 @@
+package http
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/benbjohnson/wtf"
+)
+
+const ErrInvalidJSON = wtf.Error("invalid json")
+
+// Handler is a collection of all the service handlers.
+type Handler struct {
+	DialHandler *DialHandler
+}
+
+// ServeHTTP delegates a request to the appropriate subhandler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/api/dials") {
+		h.DialHandler.ServeHTTP(w, r)
+	} else {
+		http.NotFound(w, r)
+	}
+}
+
+// Error writes an API error message to the response and logger.
+func Error(w http.ResponseWriter, err error, code int, logger *log.Logger) {
+	// Log error.
+	logger.Printf("http error: %s (code=%d)", err, code)
+
+	// Hide error from client if it is internal.
+	if code == http.StatusInternalServerError {
+		err = wtf.ErrInternal
+	}
+
+	// Write generic error response.
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(&errorResponse{Err: err.Error()})
+}
+
+// errorResponse is a generic response for sending a error.
+type errorResponse struct {
+	Err string `json:"err,omitempty"`
+}
+
+// NotFound writes an API error message to the response.
+func NotFound(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	w.Write([]byte(`{}` + "\n"))
+}
+
+// encodeJSON encodes v to w in JSON format. Error() is called if encoding fails.
+func encodeJSON(w http.ResponseWriter, v interface{}, logger *log.Logger) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		Error(w, err, http.StatusInternalServerError, logger)
+	}
+}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -1,0 +1,22 @@
+package http_test
+
+import (
+	"github.com/benbjohnson/wtf/http"
+)
+
+// Handler represents a test wrapper for http.Handler.
+type Handler struct {
+	*http.Handler
+
+	DialHandler *DialHandler
+}
+
+// NewHandler returns a new instance of Handler.
+func NewHandler() *Handler {
+	h := &Handler{
+		Handler:     &http.Handler{},
+		DialHandler: NewDialHandler(),
+	}
+	h.Handler.DialHandler = h.DialHandler.DialHandler
+	return h
+}

--- a/http/server.go
+++ b/http/server.go
@@ -1,0 +1,76 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/benbjohnson/wtf"
+)
+
+// DefaultAddr is the default bind address.
+const DefaultAddr = ":3000"
+
+// Server represents an HTTP server.
+type Server struct {
+	ln net.Listener
+
+	// Handler to serve.
+	Handler *Handler
+
+	// Bind address to open.
+	Addr string
+}
+
+// NewServer returns a new instance of Server.
+func NewServer() *Server {
+	return &Server{
+		Addr: DefaultAddr,
+	}
+}
+
+// Open opens a socket and serves the HTTP server.
+func (s *Server) Open() error {
+	// Open socket.
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		return err
+	}
+	s.ln = ln
+
+	// Start HTTP server.
+	go func() { http.Serve(s.ln, s.Handler) }()
+
+	return nil
+}
+
+// Close closes the socket.
+func (s *Server) Close() error {
+	if s.ln != nil {
+		s.ln.Close()
+	}
+	return nil
+}
+
+// Port returns the port that the server is open on. Only valid after open.
+func (s *Server) Port() int {
+	return s.ln.Addr().(*net.TCPAddr).Port
+}
+
+// Client represents a client to connect to the HTTP server.
+type Client struct {
+	URL         url.URL
+	dialService DialService
+}
+
+// NewClient returns a new instance of Client.
+func NewClient() *Client {
+	c := &Client{}
+	c.dialService.URL = &c.URL
+	return c
+}
+
+// DialService returns the service for managing dials.
+func (c *Client) DialService() wtf.DialService {
+	return &c.dialService
+}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,0 +1,59 @@
+package http_test
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/wtf/http"
+)
+
+// Now represents the mocked current time.
+var Now = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// Server represents a test wrapper for http.Server.
+type Server struct {
+	*http.Server
+
+	Handler *Handler
+}
+
+// NewServer returns a new instance of Server.
+func NewServer() *Server {
+	s := &Server{
+		Server:  http.NewServer(),
+		Handler: NewHandler(),
+	}
+	s.Server.Handler = s.Handler.Handler
+
+	// Use random port.
+	s.Addr = ":0"
+
+	return s
+}
+
+// MustOpenServerClient returns a running server and associated client. Panic on error.
+func MustOpenServerClient() (*Server, *http.Client) {
+	// Create and open test server.
+	s := NewServer()
+	if err := s.Open(); err != nil {
+		panic(err)
+	}
+
+	// Create a client pointing to the server.
+	c := http.NewClient()
+	c.URL = url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", s.Port())}
+
+	return s, c
+}
+
+// VerboseWriter returns a multi-writer to STDERR and w if the "-v" flag is set.
+func VerboseWriter(w io.Writer) io.Writer {
+	if testing.Verbose() {
+		return io.MultiWriter(w, os.Stderr)
+	}
+	return w
+}

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -11,7 +11,7 @@ type DialService struct {
 	CreateDialFn      func(dial *wtf.Dial) error
 	CreateDialInvoked bool
 
-	SetLevelFn      func(id wtf.DialID, level float64) error
+	SetLevelFn      func(id wtf.DialID, token string, level float64) error
 	SetLevelInvoked bool
 }
 
@@ -25,7 +25,7 @@ func (s *DialService) CreateDial(dial *wtf.Dial) error {
 	return s.CreateDialFn(dial)
 }
 
-func (s *DialService) SetLevel(id wtf.DialID, level float64) error {
+func (s *DialService) SetLevel(id wtf.DialID, token string, level float64) error {
 	s.SetLevelInvoked = true
-	return s.SetLevelFn(id, level)
+	return s.SetLevelFn(id, token, level)
 }


### PR DESCRIPTION
## Overview

Adds an `http` package containing a `Server` and `Client` which provide an HTTP API. The `Client` implements `wtf.Client`.

Here is the related Medium post explaining the pull request: https://medium.com/@benbjohnson/wtf-dial-http-api-d8800ccd605f
