### PR TITLE
Include benbjohnson/ego as a tool import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: generate
 
 # Runs the ego templating generation tool whenever an HTML template changes.
 generate: http/html/*.ego
-	@ego ./http/html
+	@go run github.com/benbjohnson/ego/cmd/ego ./http/html
 
 # Removes all ego Go files from the http/html directory.
 clean:

--- a/README.md
+++ b/README.md
@@ -114,10 +114,7 @@ A few smaller packages don't fall into the organization listed above:
 
 ## Development
 
-You can build `wtf` locally by cloning the repository and installing the 
-[ego](https://github.com/benbjohnson/ego) templating library.
-
-Then run:
+You can build `wtf` locally by cloning the repository, then run:
 
 ```sh
 $ make 

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 )
+
+// Build tools
+require github.com/benbjohnson/ego v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/benbjohnson/ego v0.4.1 h1:VH+pyKG++1Pd9ITFEfL3gKEEYxYIn+xS7dkhx44UuwQ=
+github.com/benbjohnson/ego v0.4.1/go.mod h1:Sa5eTS6AJJy62BL2Y4ba70gt0ZayBXw2R5yZUD1ves8=
 github.com/benbjohnson/hashfs v0.1.0 h1:IDx9WvG81QRFZbXlpOki65OBpCpLcCi8Avl/S+8Q31s=
 github.com/benbjohnson/hashfs v0.1.0/go.mod h1:7OMXaMVo1YkfiIPxKrl7OXkUTUgWjmsAKyR+E6xDIRM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,9 @@
+// +build tools
+
+package wtf
+
+// These imports ensure build tools are included in Go modules.
+// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+import (
+	_ "github.com/benbjohnson/ego"
+)


### PR DESCRIPTION
Currently, users need to install an external command on their system to be able to run the `make` command, as documented in the README.

There is a trick documented in the [Go wiki](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module) for including "tools" along other project modules, and being able to `go run` them directly in the context of the project. This approach might be a little controversial but, since `wtf` is an educational project, I figured I could try to make it as easy as possible to run it by using this hack to vendor `ego`, and save users the effort of installing it.